### PR TITLE
aws_source_ami_filter_version 0.1.26 to 0.1.27 to include ec2-metadat…

### DIFF
--- a/packer/sources.pkr.hcl
+++ b/packer/sources.pkr.hcl
@@ -12,7 +12,7 @@ source "amazon-ebs" "builder" {
   kms_key_id           = var.kms_key_id
 
   launch_block_device_mappings {
-    device_name = "/dev/xvda"
+    device_name = "/dev/sda1"
     volume_size = var.root_volume_size_gb
     volume_type = "gp3"
     delete_on_termination = true

--- a/packer/variables.pkr.hcl
+++ b/packer/variables.pkr.hcl
@@ -35,7 +35,7 @@ variable "aws_source_ami_filter_name" {
 
 variable "aws_source_ami_filter_version" {
   type        = string
-  default     = "0.1.26"
+  default     = "0.1.27"
   description = "The source AMI filter version. Used to enable control of version of source AMI from CI triggers."
 }
 


### PR DESCRIPTION
aws_source_ami_filter_version 0.1.26 to 0.1.27, include ec2-metadata 0.1.1 to 0.1.2
revert launch_block_device_mappings device_name xvda to sda1, account for iprocess-base-ami device map